### PR TITLE
Removed second entry of libbzip2

### DIFF
--- a/INSTALL.in
+++ b/INSTALL.in
@@ -127,7 +127,6 @@ header files installed.
 
      ATK     		@ATK_REQUIRED_VERSION@
      babl		@BABL_REQUIRED_VERSION@
-     libbzip2
      cairo 		@CAIRO_REQUIRED_VERSION@
      Fontconfig 	@FONTCONFIG_REQUIRED_VERSION@
      freetype2 		@FREETYPE2_REQUIRED_VERSION@


### PR DESCRIPTION
libbzip2 had two entries in the summary of required packages.