### PR TITLE
app: fix source comment typos

### DIFF
--- a/app/actions/debug-commands.c
+++ b/app/actions/debug-commands.c
@@ -193,7 +193,7 @@ debug_dump_keyboard_shortcuts_cmd_callback (GtkAction *action,
 
   accel_group = gtk_ui_manager_get_accel_group (manager);
 
-  /* Gather formated strings of keyboard shortcuts */
+  /* Gather formatted strings of keyboard shortcuts */
   for (group_it = gtk_ui_manager_get_action_groups (manager);
        group_it;
        group_it = g_list_next (group_it))

--- a/app/app.c
+++ b/app/app.c
@@ -211,7 +211,7 @@ app_run (const gchar         *full_prog_name,
     }
 
   /* Language needs to be determined first, before any GimpContext is
-   * instanciated (which happens when the Gimp object is created)
+   * instantiated (which happens when the Gimp object is created)
    * because its properties need to be properly localized in the
    * settings language (if different from system language). Otherwise we
    * end up with pieces of GUI always using the system language (cf. bug

--- a/app/core/gimpboundary.c
+++ b/app/core/gimpboundary.c
@@ -146,7 +146,7 @@ static void       simplify_subdivide  (const GimpBoundSeg  *segs,
  * outlines along pixel value @threahold, optionally within specified
  * bounds instead of the whole region.
  *
- * The @maskPR paramater can be any PixelRegion.  If the region has
+ * The @maskPR parameter can be any PixelRegion.  If the region has
  * more than 1 bytes/pixel, the last byte of each pixel is used to
  * determine the boundary outline.
  *
@@ -394,7 +394,7 @@ gimp_boundary_offset (GimpBoundSeg *segs,
 
   for (i = 0; i < num_segs; i++)
     {
-      /* dont offset sorting sentinels */
+      /* don't offset sorting sentinels */
       if (!(segs[i].x1 == -1 &&
             segs[i].y1 == -1 &&
             segs[i].x2 == -1 &&

--- a/app/core/gimpbrush.c
+++ b/app/core/gimpbrush.c
@@ -631,7 +631,7 @@ gimp_brush_transform_mask (GimpBrush *brush,
        * This is intentional. Confoliving for each stamp is too expensive.*/
       if (! brush->priv->blured_mask &&
           ! GIMP_IS_BRUSH_GENERATED(brush) &&
-          ! GIMP_IS_BRUSH_PIPE(brush) && /*Cant cache pipes. Sanely anway*/
+          ! GIMP_IS_BRUSH_PIPE(brush) && /*Can't cache pipes. Sanely anyway*/
           hardness < 1.0)
         {
            brush->priv->blured_mask = GIMP_BRUSH_GET_CLASS (brush)->transform_mask (brush,
@@ -724,7 +724,7 @@ gimp_brush_transform_pixmap (GimpBrush *brush,
 #if 0
      if (! brush->priv->blured_pixmap &&
          ! GIMP_IS_BRUSH_GENERATED(brush) &&
-         ! GIMP_IS_BRUSH_PIPE(brush) /*Cant cache pipes. Sanely anway*/
+         ! GIMP_IS_BRUSH_PIPE(brush) /*Can't cache pipes. Sanely anyway*/
          && hardness < 1.0)
       {
          brush->priv->blured_pixmap = GIMP_BRUSH_GET_CLASS (brush)->transform_pixmap (brush,

--- a/app/core/gimpdrawable-preview.h
+++ b/app/core/gimpdrawable-preview.h
@@ -20,7 +20,7 @@
 
 
 /*
- *  virtual functions of GimpDrawable -- dont't call directly
+ *  virtual functions of GimpDrawable -- don't call directly
  */
 GimpTempBuf * gimp_drawable_get_new_preview    (GimpViewable *viewable,
                                                 GimpContext  *context,

--- a/app/core/gimpdrawablefilter.c
+++ b/app/core/gimpdrawablefilter.c
@@ -18,7 +18,7 @@
 /* This file contains the code necessary for generating on canvas
  * previews, by connecting a specified GEGL operation to do the
  * processing. It uses drawable filters that allow for non-destructive
- * manupulation of drawable data, with live preview on screen.
+ * manipulation of drawable data, with live preview on screen.
  *
  * To create a tool that uses this, see app/tools/gimpfiltertool.c for
  * the interface and e.g. app/tools/gimpcolorbalancetool.c for an

--- a/app/core/gimpdynamicsoutput.c
+++ b/app/core/gimpdynamicsoutput.c
@@ -534,7 +534,7 @@ gimp_dynamics_output_get_angular_value (GimpDynamicsOutput *output,
 {
   GimpDynamicsOutputPrivate *private = GET_PRIVATE (output);
   gdouble                    total   = 0.0;
-  gdouble                    result  = 0.0; /* angles are additive, so we retun zero for no change. */
+  gdouble                    result  = 0.0; /* angles are additive, so we return zero for no change. */
   gint                       factors = 0;
 
   if (private->use_pressure)

--- a/app/core/gimpimage-convert-indexed.c
+++ b/app/core/gimpimage-convert-indexed.c
@@ -633,7 +633,7 @@ make_remap_table (const guchar  old_palette[],
         }
     }
 
-  /* Third pass - rank all used indicies to the beginning of the
+  /* Third pass - rank all used indices to the beginning of the
    * palette.
    */
   palentries = g_new (PalEntry, used);

--- a/app/core/gimpimage-guides.h
+++ b/app/core/gimpimage-guides.h
@@ -29,7 +29,7 @@ GimpGuide * gimp_image_add_vguide     (GimpImage *image,
                                        gboolean   push_undo);
 
 /*  internal guide adding API, does not check the guide's position and
- *  is publically declared only to be used from undo
+ *  is publicly declared only to be used from undo
  */
 void        gimp_image_add_guide      (GimpImage *image,
                                        GimpGuide *guide,

--- a/app/core/gimpimage-preview.h
+++ b/app/core/gimpimage-preview.h
@@ -20,7 +20,7 @@
 
 
 /*
- *  virtual functions of GimpImage -- dont't call directly
+ *  virtual functions of GimpImage -- don't call directly
  */
 
 void          gimp_image_get_preview_size (GimpViewable *viewable,

--- a/app/core/gimpimage-sample-points.h
+++ b/app/core/gimpimage-sample-points.h
@@ -27,7 +27,7 @@ GimpSamplePoint * gimp_image_add_sample_point_at_pos (GimpImage        *image,
                                                       gboolean          push_undo);
 
 /*  internal sample point adding API, does not check the sample
- *  point's position and is publically declared only to be used from
+ *  point's position and is publicly declared only to be used from
  *  undo
  */
 void              gimp_image_add_sample_point        (GimpImage       *image,

--- a/app/core/gimpimageundo.c
+++ b/app/core/gimpimageundo.c
@@ -335,7 +335,7 @@ gimp_image_undo_pop (GimpUndo            *undo,
             if ((image_undo->base_type            == GIMP_GRAY) ||
                 (gimp_image_get_base_type (image) == GIMP_GRAY))
               {
-                /* in case ther was no profile undo, we need to emit
+                /* in case there was no profile undo, we need to emit
                  * profile-changed anyway
                  */
                 gimp_color_managed_profile_changed (GIMP_COLOR_MANAGED (image));

--- a/app/core/gimpitem-preview.h
+++ b/app/core/gimpitem-preview.h
@@ -20,7 +20,7 @@
 
 
 /*
- *  virtual functions of GimpItem -- dont't call directly
+ *  virtual functions of GimpItem -- don't call directly
  */
 
 void      gimp_item_get_preview_size (GimpViewable *viewable,

--- a/app/core/gimppickable-contiguous-region.c
+++ b/app/core/gimppickable-contiguous-region.c
@@ -201,7 +201,7 @@ gimp_pickable_contiguous_region_by_color (GimpPickable        *pickable,
     {
       if (select_transparent)
         {
-          /*  don't select transparancy if "color" isn't fully transparent
+          /*  don't select transparency if "color" isn't fully transparent
            */
           if (start_col[n_components - 1] > 0.0)
             select_transparent = FALSE;

--- a/app/core/gimptag.c
+++ b/app/core/gimptag.c
@@ -157,7 +157,7 @@ gimp_tag_get_internal (GimpTag *tag)
  * @tag: a gimp tag.
  * @inernal: desired tag internal status
  *
- * Set internal status of the tag. Internal tags are usually automaticaly
+ * Set internal status of the tag. Internal tags are usually automatically
  * generated and will not be saved into users tag cache.
  *
  **/

--- a/app/core/gimpviewable.c
+++ b/app/core/gimpviewable.c
@@ -848,7 +848,7 @@ gimp_viewable_get_popup_size (GimpViewable *viewable,
  * method, and executes it, caching the result.  If everything fails,
  * #NULL is returned.
  *
- * Returns: A #GimpTempBuf containg the preview image, or #NULL if
+ * Returns: A #GimpTempBuf containing the preview image, or #NULL if
  *          none can be found or created.
  **/
 GimpTempBuf *
@@ -911,7 +911,7 @@ gimp_viewable_get_preview (GimpViewable *viewable,
  * then if that fails for a "get_preview" method.  This function does
  * not look for a cached preview.
  *
- * Returns: A #GimpTempBuf containg the preview image, or #NULL if
+ * Returns: A #GimpTempBuf containing the preview image, or #NULL if
  *          none can be found or created.
  **/
 GimpTempBuf *

--- a/app/display/gimpdisplayshell.c
+++ b/app/display/gimpdisplayshell.c
@@ -773,7 +773,7 @@ gimp_display_shell_constructed (GObject *object)
       gimp_display_shell_connect (shell);
 
       /* After connecting to the image we want to center it. Since we
-       * not even finnished creating the display shell, we can safely
+       * not even finished creating the display shell, we can safely
        * assume we will get a size-allocate later.
        */
       gimp_display_shell_scroll_center_image_on_size_allocate (shell,

--- a/app/display/gimpimagewindow.c
+++ b/app/display/gimpimagewindow.c
@@ -1641,7 +1641,7 @@ gimp_image_window_get_first_dockbook (GimpDockColumns *columns)
  * dockables should be put in single-window mode.
  *
  * Returns: The default dockbook for new dockables, or NULL if no
- *          dockbook were avaialble.
+ *          dockbook were available.
  **/
 GtkWidget *
 gimp_image_window_get_default_dockbook (GimpImageWindow  *window)

--- a/app/display/gimpmotionbuffer.c
+++ b/app/display/gimpmotionbuffer.c
@@ -243,7 +243,7 @@ gimp_motion_buffer_end_stroke (GimpMotionBuffer *buffer)
  * tilt values, to allow for even more dynamic brushes. Calculated
  * distance to last event is stored in GimpCoords because its a
  * sideproduct of velocity calculation and is currently calculated in
- * each tool. If they were to use this distance, more resouces on
+ * each tool. If they were to use this distance, more resources on
  * recalculating the same value would be saved.
  *
  * Return value: %TRUE if the motion was significant enough to be

--- a/app/display/gimpmotionbuffer.h
+++ b/app/display/gimpmotionbuffer.h
@@ -50,7 +50,7 @@ struct _GimpMotionBuffer
 
   GArray     *event_history;
   GArray     *event_queue;
-  gboolean    event_delay;      /* TRUE if theres an unsent event in
+  gboolean    event_delay;      /* TRUE if there's an unsent event in
                                  *  the history buffer
                                  */
 

--- a/app/display/gimptoolrectangle.c
+++ b/app/display/gimptoolrectangle.c
@@ -1445,7 +1445,7 @@ gimp_tool_rectangle_button_press (GimpToolWidget      *widget,
        * what coordinates the "other side" should have. If we are
        * creating a rectangle, use the current mouse coordinates as
        * the coordinate of the "other side", otherwise use the
-       * immidiate "other side" for that.
+       * immediate "other side" for that.
        */
       private->other_side_x = snapped_x;
       private->other_side_y = snapped_y;
@@ -1868,7 +1868,7 @@ gimp_tool_rectangle_motion_modifier (GimpToolWidget  *widget,
   if (key == gimp_get_extend_selection_mask ())
     {
 #if 0
-      /* Here we want to handle manualy when to update the rectangle, so we
+      /* Here we want to handle manually when to update the rectangle, so we
        * don't want gimp_tool_rectangle_options_notify to do anything.
        */
       g_signal_handlers_block_by_func (options,
@@ -2299,7 +2299,7 @@ gimp_tool_rectangle_check_function (GimpToolRectangle *rectangle)
 /**
  * gimp_tool_rectangle_coord_outside:
  *
- * Returns: %TRUE if the coord is outside the rectange bounds
+ * Returns: %TRUE if the coord is outside the rectangle bounds
  *          including any outside handles.
  */
 static gboolean
@@ -3695,7 +3695,7 @@ gimp_tool_rectangle_get_constraints (GimpToolRectangle       *rectangle,
  * gimp_tool_rectangle_handle_general_clamping:
  * @rectangle: A #GimpToolRectangle.
  *
- * Make sure that contraints are applied to the rectangle, either by
+ * Make sure that constraints are applied to the rectangle, either by
  * manually doing it, or by looking at the rectangle tool options and
  * concluding it will be done later.
  */

--- a/app/gegl/gimp-babl.c
+++ b/app/gegl/gimp-babl.c
@@ -257,7 +257,7 @@ void
 gimp_babl_init_fishes (GimpInitStatusFunc status_callback)
 {
   /* create a bunch of fishes - to decrease the initial lazy
-   * intialization cost for some interactions
+   * initialization cost for some interactions
    */
   static const struct
   {

--- a/app/gui/gui-message.c
+++ b/app/gui/gui-message.c
@@ -361,7 +361,7 @@ gui_message_error_dialog (Gimp                *gimp,
           gimp_enum_get_value (GIMP_TYPE_MESSAGE_SEVERITY, severity,
                                NULL, NULL, &reason, NULL);
 
-          /* Since we overrided glib default's WARNING and CRITICAL
+          /* Since we overridden glib default's WARNING and CRITICAL
            * handler, if we decide not to handle this error in the end,
            * let's just print it in terminal in a similar fashion as
            * glib's default handler (though without the fancy terminal

--- a/app/gui/gui-unique.c
+++ b/app/gui/gui-unique.c
@@ -334,7 +334,7 @@ gui_unique_quartz_init (Gimp *gimp)
                     G_CALLBACK (gui_unique_quartz_nsopen_file_callback),
                     gimp);
 
-  /* Using the event handler is a hack, it is neccesary becuase
+  /* Using the event handler is a hack, it is necessary because
    * gtkosx_application will drop the file open events if any
    * event processing is done before gtkosx_application_ready is
    * called, which we unfortuantly can't avoid doing right now.

--- a/app/gui/gui.c
+++ b/app/gui/gui.c
@@ -237,7 +237,7 @@ gui_init (Gimp     *gimp,
     /* Normally this should have been taken care of during command line
      * parsing as a post-parse hook of gtk_get_option_group(), using the
      * system locales.
-     * But user config may have overriden the language, therefore we must
+     * But user config may have overridden the language, therefore we must
      * check the widget directions again.
      */
     gtk_widget_set_default_direction (GTK_TEXT_DIR_RTL);

--- a/app/operations/gimpoperationborder.c
+++ b/app/operations/gimpoperationborder.c
@@ -451,7 +451,7 @@ gimp_operation_border_process (GeglOperation       *operation,
 
       g_free (transition);
 
-      /* Finnished handling the radius = 1 special case, return here. */
+      /* Finished handling the radius = 1 special case, return here. */
       return TRUE;
     }
 

--- a/app/operations/gimpoperationgrow.c
+++ b/app/operations/gimpoperationgrow.c
@@ -231,7 +231,7 @@ gimp_operation_grow_process (GeglOperation       *operation,
                              const GeglRectangle *roi,
                              gint                 level)
 {
-  /* Any bugs in this fuction are probably also in thin_region.
+  /* Any bugs in this function are probably also in thin_region.
    * Blame all bugs in this function on jaycox@gimp.org
    */
   GimpOperationGrow *self          = GIMP_OPERATION_GROW (operation);

--- a/app/paint/gimpbrushcore.c
+++ b/app/paint/gimpbrushcore.c
@@ -521,7 +521,7 @@ gimp_brush_core_interpolate (GimpPaintCore    *paint_core,
       gimp_paint_core_paint (paint_core, drawable, paint_options,
                              GIMP_PAINT_STATE_MOTION, time);
 
-      paint_core->pixel_dist = pixel_initial + pixel_dist; /* Dont forget to update pixel distance*/
+      paint_core->pixel_dist = pixel_initial + pixel_dist; /* Don't forget to update pixel distance*/
 
       return;
     }
@@ -675,7 +675,7 @@ gimp_brush_core_interpolate (GimpPaintCore    *paint_core,
         {
           /*  Exception A: If the first stripe's brush position is
            *  EXTRApolated into a different pixel square than the
-           *  ideal starting point, dont't plot it.
+           *  ideal starting point, don't plot it.
            */
           s0 += direction;
         }
@@ -1577,7 +1577,7 @@ gimp_brush_core_eval_transform_dynamics (GimpBrushCore     *core,
 
           /* Zero aspect ratio is special cased to half of all ar range,
            * to force dynamics to have any effect. Forcing to full results
-           * in disapearing stamp if applied to maximum.
+           * in disappearing stamp if applied to maximum.
            */
           if (core->aspect_ratio == 0.0)
             core->aspect_ratio = 10.0 * dyn_aspect;
@@ -1693,7 +1693,7 @@ gimp_brush_core_paint_line_pixmap_mask (GimpDrawable             *drawable,
   pixmap_precision = gimp_babl_format_get_precision (pixmap_format);
   pixmap_bytes     = babl_format_get_bytes_per_pixel (pixmap_format);
 
-  /* Point to the approriate scanline */
+  /* Point to the appropriate scanline */
   b = (gimp_temp_buf_get_data (pixmap_mask) +
        (y % pixmap_height) * pixmap_width * pixmap_bytes);
 

--- a/app/paint/gimpmybrushsurface.c
+++ b/app/paint/gimpmybrushsurface.c
@@ -436,7 +436,7 @@ gimp_mypaint_surface_draw_dab (MyPaintSurface *base_surface,
               if (a > 0.0f)
                 {
                   /* By definition the ratio between each color[] and pixel[] component in a non-pre-multipled blend always sums to 1.0f.
-                   * Originaly this would have been "(color[n] * alpha * color_a + pixel[n] * dst_alpha * (1.0f - alpha)) / a",
+                   * Originally this would have been "(color[n] * alpha * color_a + pixel[n] * dst_alpha * (1.0f - alpha)) / a",
                    * instead we only calculate the cheaper term. */
                   float src_term = (alpha * color_a) / a;
                   float dst_term = 1.0f - src_term;

--- a/app/paint/gimppaintcore-loops.c
+++ b/app/paint/gimppaintcore-loops.c
@@ -242,7 +242,7 @@ paint_mask_to_paint_buffer (const GimpTempBuf  *paint_mask,
   int iy, ix;
   gfloat *paint_pixel = (gfloat *)gimp_temp_buf_get_data (paint_buf);
 
-  /* Validate that the paint buffer is withing the bounds of the paint mask */
+  /* Validate that the paint buffer is within the bounds of the paint mask */
   g_return_if_fail (width <= gimp_temp_buf_get_width (paint_mask) - mask_x_offset);
   g_return_if_fail (height <= gimp_temp_buf_get_height (paint_mask) - mask_y_offset);
 

--- a/app/paint/gimppaintcore.c
+++ b/app/paint/gimppaintcore.c
@@ -678,7 +678,7 @@ gimp_paint_core_get_last_coords (GimpPaintCore *core,
  *
  * Adjusts core->last_coords and core_cur_coords in preparation to
  * drawing a straight line. If @center_pixels is TRUE the endpoints
- * get pushed to the center of the pixels. This avoids artefacts
+ * get pushed to the center of the pixels. This avoids artifacts
  * for e.g. the hard mode. The rounding of the slope to 15 degree
  * steps if ctrl is pressed happens, as does rounding the start and
  * end coordinates (which may be fractional in high zoom modes) to
@@ -1090,7 +1090,7 @@ gimp_paint_core_smooth_coords (GimpPaintCore    *core,
   GArray               *history           = core->stroke_buffer;
 
   if (core->stroke_buffer == NULL)
-    return; /* Paint core has not initalized yet */
+    return; /* Paint core has not initialized yet */
 
   if (smoothing_options->use_smoothing &&
       smoothing_options->smoothing_quality > 0)
@@ -1106,7 +1106,7 @@ gimp_paint_core_smooth_coords (GimpPaintCore    *core,
       g_array_append_val (history, *coords);
 
       if (history->len < 2)
-        return; /* Just dont bother, nothing to do */
+        return; /* Just don't bother, nothing to do */
 
       coords->x = coords->y = 0.0;
 

--- a/app/pdb/plug-in-compat-cmds.c
+++ b/app/pdb/plug-in-compat-cmds.c
@@ -7904,7 +7904,7 @@ register_plug_in_compat_procs (GimpPDB *pdb)
   gimp_procedure_add_argument (procedure,
                                g_param_spec_double ("blend-power",
                                                     "blend power",
-                                                    "Power used to strech the blend",
+                                                    "Power used to stretch the blend",
                                                     -G_MAXDOUBLE, G_MAXDOUBLE, 0,
                                                     GIMP_PARAM_READWRITE));
   gimp_pdb_register_procedure (pdb, procedure);

--- a/app/plug-in/gimppluginmanager-file-procedure.c
+++ b/app/plug-in/gimppluginmanager-file-procedure.c
@@ -42,7 +42,7 @@
 
 typedef enum
 {
-  /*  positive values indicate the lenght of a matching magic  */
+  /*  positive values indicate the length of a matching magic  */
 
   FILE_MATCH_NONE = 0,
   FILE_MATCH_SIZE = -1

--- a/app/plug-in/gimppluginmanager.c
+++ b/app/plug-in/gimppluginmanager.c
@@ -257,7 +257,7 @@ gimp_plug_in_manager_exit (GimpPlugInManager *manager)
   while (manager->open_plug_ins)
     gimp_plug_in_close (manager->open_plug_ins->data, TRUE);
 
-  /*  need to deatch from shared memory, we can't rely on exit()
+  /*  need to detach from shared memory, we can't rely on exit()
    *  cleaning up behind us (see bug #609026)
    */
   if (manager->shm)

--- a/app/tests/test-ui.c
+++ b/app/tests/test-ui.c
@@ -433,7 +433,7 @@ restore_recently_closed_multi_column_dock (gconstpointer data)
 #warning FIXME test disabled until we depend on GTK+ >= 2.24.11
 #endif
 #if 0
-  /* Restore the (only avaiable) closed dock and make sure the session
+  /* Restore the (only available) closed dock and make sure the session
    * infos in the global dock factory are increased again
    */
   gimp_ui_manager_activate_action (gimp_test_utils_get_ui_manager (gimp),

--- a/app/tools/gimpcagetool.h
+++ b/app/tools/gimpcagetool.h
@@ -61,7 +61,7 @@ struct _GimpCageTool
   GeglBuffer     *coef; /* Gegl buffer where the coefficient of the transformation are stored */
   gboolean        dirty_coef; /* Indicate if the coef are still valid */
 
-  GeglNode       *render_node; /* Gegl node graph to render the transfromation */
+  GeglNode       *render_node; /* Gegl node graph to render the transformation */
   GeglNode       *cage_node; /* Gegl node that compute the cage transform */
   GeglNode       *coef_node; /* Gegl node that read in the coef buffer */
 

--- a/app/tools/gimpfliptool.c
+++ b/app/tools/gimpfliptool.c
@@ -155,7 +155,7 @@ static GimpDisplay *
 gimp_flip_tool_has_image (GimpTool  *tool,
                           GimpImage *image)
 {
-  /* avoid comitting, and hence flipping, when changing tools */
+  /* avoid committing, and hence flipping, when changing tools */
   return NULL;
 }
 
@@ -372,7 +372,7 @@ gimp_flip_tool_transform (GimpTransformTool *trans_tool,
        *  normal drawable, or the selection
        */
 
-      /*  always clip the selction and unfloated channels
+      /*  always clip the selection and unfloated channels
        *  so they keep their size
        */
       if (GIMP_IS_CHANNEL (active_item) &&

--- a/app/tools/gimpiscissorstool.c
+++ b/app/tools/gimpiscissorstool.c
@@ -335,7 +335,7 @@ gimp_iscissors_tool_class_init (GimpIscissorsToolClass *klass)
       direction_value[i][3] = abs (63 - i) * 2;
     }
 
-  /*  set the 256th index of the direction_values to the hightest cost  */
+  /*  set the 256th index of the direction_values to the highest cost  */
   direction_value[255][0] = 255;
   direction_value[255][1] = 255;
   direction_value[255][2] = 255;

--- a/app/tools/gimpoperationtool.c
+++ b/app/tools/gimpoperationtool.c
@@ -254,7 +254,7 @@ gimp_operation_tool_options_notify (GimpTool         *tool,
        * controller to move to a new position, or the operation to
        * change its properties to match the on-canvas controller?
        *
-       * decided to leave the on-canvas controler where it is and
+       * decided to leave the on-canvas controller where it is and
        * pretend it has changed, so the operation is updated
        * accordingly...
        */

--- a/app/tools/gimppainttool.c
+++ b/app/tools/gimppainttool.c
@@ -574,7 +574,7 @@ gimp_paint_tool_cursor_update (GimpTool         *tool,
   GIMP_TOOL_CLASS (parent_class)->cursor_update (tool, coords, state,
                                                  display);
 
-  /*  reset old stuff here so we are not interferring with the modifiers
+  /*  reset old stuff here so we are not interfering with the modifiers
    *  set by our subclasses
    */
   gimp_tool_control_set_cursor_modifier        (tool->control,

--- a/app/tools/gimpseamlessclonetool.c
+++ b/app/tools/gimpseamlessclonetool.c
@@ -267,10 +267,10 @@ gimp_seamless_clone_tool_control (GimpTool       *tool,
  * @display: The display to initialize the tool for
  *
  * A utility function to initialize a tool for working on a given
- * display. At the begining of each function, we can check if the event's
+ * display. At the beginning of each function, we can check if the event's
  * display is the same as the tool's one, and if not call this. This is
  * not required by the gimptool interface or anything like that, but
- * this is a convinient way to do all the initialization work in one
+ * this is a convenient way to do all the initialization work in one
  * place, and this is how the base class (GimpDrawTool) does that
  */
 static void
@@ -632,7 +632,7 @@ gimp_seamless_clone_tool_draw (GimpDrawTool *draw_tool)
 
 /**
  * gimp_seamless_clone_tool_create_render_node:
- * @sc: The GimpSeamlessCloneTool to intialize
+ * @sc: The GimpSeamlessCloneTool to initialize
  *
  * This function creates a Gegl node graph of the composition which is
  * needed to render the drawable. The graph should have an "input" pad

--- a/app/tools/gimptransformtool.c
+++ b/app/tools/gimptransformtool.c
@@ -777,7 +777,7 @@ gimp_transform_tool_real_transform (GimpTransformTool *tr_tool,
        *  normal drawable, or the selection
        */
 
-      /*  always clip the selction and unfloated channels
+      /*  always clip the selection and unfloated channels
        *  so they keep their size
        */
       if (GIMP_IS_CHANNEL (active_item) &&

--- a/app/tools/gimpwarptool.c
+++ b/app/tools/gimpwarptool.c
@@ -815,7 +815,7 @@ static void
 gimp_warp_tool_create_graph (GimpWarpTool *wt)
 {
   GimpWarpOptions *options = GIMP_WARP_TOOL_GET_OPTIONS (wt);
-  GeglNode        *graph;           /* Wraper to be returned */
+  GeglNode        *graph;           /* Wrapper to be returned */
   GeglNode        *input, *output;  /* Proxy nodes */
   GeglNode        *coords, *render; /* Render nodes */
 

--- a/app/vectors/gimpbezierstroke.c
+++ b/app/vectors/gimpbezierstroke.c
@@ -2108,7 +2108,7 @@ gimp_bezier_stroke_arcto (GimpStroke       *bez_stroke,
 
   if (lambda < 0.00001)
     {
-      /* dont bother with it - endpoint is too close to startpoint */
+      /* don't bother with it - endpoint is too close to startpoint */
       return;
     }
 

--- a/app/vectors/gimpvectors-preview.h
+++ b/app/vectors/gimpvectors-preview.h
@@ -20,7 +20,7 @@
 
 
 /*
- *  virtual function of GimpVectors -- dont't call directly
+ *  virtual function of GimpVectors -- don't call directly
  */
 
 GimpTempBuf * gimp_vectors_get_new_preview (GimpViewable *viewable,

--- a/app/widgets/gimpaction-history.c
+++ b/app/widgets/gimpaction-history.c
@@ -384,7 +384,7 @@ gimp_action_history_activate_callback (GtkAction *action,
   link = g_hash_table_lookup (history.links, action_name);
 
   /* If the action is not in the history, insert it
-   * at the back of the hisory queue, possibly
+   * at the back of the history queue, possibly
    * replacing the last item.
    */
   if (! link)

--- a/app/widgets/gimpdnd.c
+++ b/app/widgets/gimpdnd.c
@@ -1158,7 +1158,7 @@ gimp_dnd_uri_list_dest_add (GtkWidget              *widget,
 {
   g_return_if_fail (GTK_IS_WIDGET (widget));
 
-  /*  Set a default drag dest if not already done. Explicitely set
+  /*  Set a default drag dest if not already done. Explicitly set
    *  COPY and MOVE for file drag destinations. Some file managers
    *  such as Konqueror only offer MOVE by default.
    */

--- a/app/widgets/gimpdock.c
+++ b/app/widgets/gimpdock.c
@@ -759,7 +759,7 @@ gimp_dock_temp_add (GimpDock  *dock,
  * @dock:
  * @child:
  *
- * Removes a temporarly child added with gimp_dock_temp_add().
+ * Removes a temporary child added with gimp_dock_temp_add().
  **/
 void
 gimp_dock_temp_remove (GimpDock  *dock,

--- a/app/widgets/gimpdockbook.c
+++ b/app/widgets/gimpdockbook.c
@@ -999,7 +999,7 @@ gimp_dockbook_add (GimpDockbook *dockbook,
  * @identifiers: The dockable identifier(s)
  * @position:    The insert position
  *
- * Add a dockable from the dialog factory associated wth the dockbook.
+ * Add a dockable from the dialog factory associated with the dockbook.
  **/
 GtkWidget *
 gimp_dockbook_add_from_dialog_factory (GimpDockbook *dockbook,

--- a/app/widgets/gimphistogramview.c
+++ b/app/widgets/gimphistogramview.c
@@ -589,7 +589,7 @@ gimp_histogram_view_motion_notify (GtkWidget      *widget,
 }
 
 
-/*  public funcions  */
+/*  public functions  */
 
 GtkWidget *
 gimp_histogram_view_new (gboolean range)

--- a/app/widgets/gimppaletteview.c
+++ b/app/widgets/gimppaletteview.c
@@ -419,7 +419,7 @@ gimp_palette_view_select_entry (GimpPaletteView  *view,
 }
 
 
-/*  private funcions  */
+/*  private functions  */
 
 static GimpPaletteEntry *
 gimp_palette_view_find_entry (GimpPaletteView *view,

--- a/app/widgets/gimppanedbox.c
+++ b/app/widgets/gimppanedbox.c
@@ -218,7 +218,7 @@ gimp_paned_box_set_widget_drag_handler (GtkWidget    *widget,
    * dock and a toolbox for example, in which case we want to set a
    * drag handler in two ways
    *
-   * We so need to introduce som abstractions here...
+   * We so need to introduce some abstractions here...
    */
 
   if (GIMP_IS_DOCKBOOK (widget))
@@ -573,7 +573,7 @@ gimp_paned_box_add_widget (GimpPanedBox *paned_box,
           parent     = grandparent;
         }
 
-      /* Deatch the widget and bulid up a new hierarchy */
+      /* Detach the widget and build up a new hierarchy */
       g_object_ref (old_widget);
       gtk_container_remove (GTK_CONTAINER (parent), old_widget);
 

--- a/app/widgets/gimpsearchpopup.c
+++ b/app/widgets/gimpsearchpopup.c
@@ -458,7 +458,7 @@ gimp_search_popup_size_allocate (GtkWidget     *widget,
       GdkScreen *screen = gdk_screen_get_default ();
 
       /* Save the window height when results are shown so that resizes
-       * by the user are saved accross searches.
+       * by the user are saved across searches.
        */
       window_height = MAX (gdk_screen_get_height (screen) / 4,
                            allocation->height);

--- a/app/widgets/gimpselectiondata.c
+++ b/app/widgets/gimpselectiondata.c
@@ -384,7 +384,7 @@ gimp_selection_data_get_xcf (GtkSelectionData *selection,
     }
   else
     {
-      g_warning ("Recieved invalid XCF data: %s", error->message);
+      g_warning ("Received invalid XCF data: %s", error->message);
       g_clear_error (&error);
     }
 

--- a/app/xcf/xcf-save.c
+++ b/app/xcf/xcf-save.c
@@ -1990,7 +1990,7 @@ xcf_save_old_paths (XcfInfo    *info,
 
       /* if no points are generated because of a faulty path we should
        * skip saving the path - this is unfortunately impossible, because
-       * we already saved the number of paths and I wont start seeking
+       * we already saved the number of paths and I won't start seeking
        * around to fix that cruft  */
 
       name     = (gchar *) gimp_object_get_name (vectors);


### PR DESCRIPTION
Found via `codespell -q 3 --skip="./po*"`

Edit: @Jehan sorry for this PR and not going through bugzilla, but I got really turned around trying to submit a patch there. Perhaps you can submit this patch as a test and also commit it if it's approved? 

Edit 2: I look forward to the migration to gitlab