### PR TITLE
webpmux: fix memory leak by calling WebPMuxDelete()

### DIFF
--- a/plug-ins/file-webp/file-webp-load.c
+++ b/plug-ins/file-webp/file-webp-load.c
@@ -144,7 +144,10 @@ load_image (const gchar *filename,
 
       /* Check to ensure the image data was loaded correctly */
       if (! outdata)
-        return -1;
+        {
+          WebPMuxDelete (mux);
+          return -1;
+        }
 
       create_layer (image_ID, outdata, 0, _("Background"),
                     width, height);
@@ -173,6 +176,7 @@ load_image (const gchar *filename,
               WebPDemuxDelete (demux);
             }
 
+          WebPMuxDelete (mux);
           return -1;
         }
 
@@ -276,6 +280,8 @@ load_image (const gchar *filename,
 
       g_object_unref (file);
     }
+
+  WebPMuxDelete (mux);
 
   gimp_image_set_filename (image_ID, filename);
 

--- a/plug-ins/file-webp/file-webp-save.c
+++ b/plug-ins/file-webp/file-webp-save.c
@@ -316,6 +316,8 @@ save_layer (const gchar    *filename,
                   rewind (outfile);
                   webp_anim_file_writer (outfile, wp_data.bytes, wp_data.size);
                 }
+
+              WebPMuxDelete (mux);
             }
           else
             {


### PR DESCRIPTION
Hi,

not sure why it wasn't catch before, but some destructor calls were missing...

skal/