### PR TITLE
[csource-rle] compensate for null byte

### DIFF
--- a/plug-ins/common/file-csource.c
+++ b/plug-ins/common/file-csource.c
@@ -873,7 +873,7 @@ save_image (GFile         *file,
       if (config_use_rle)
         {
           if (! print (output, error,
-                       "%u] =\n",
+                       "%u + 1] =\n",
                        (guint) (img_buffer_end - img_buffer)))
             goto fail;
         }


### PR DESCRIPTION
When exporting a C source file with runtime length encoding, the C-string's array size does not accomodate for the null byte. However, GIMP accomodates for the NULL byte in it's NON-RLE export, suggesting that this has been a mere oversight for RLE.

This can cause at the worst a compile-time error and at least a warning from the compiler. Attached is the expected fix if you would like to dismiss the compiler warning / error.