### PR TITLE
TIFF-saving: Fix handling of colormap case

### DIFF
--- a/plug-ins/file-tiff/file-tiff-save.c
+++ b/plug-ins/file-tiff/file-tiff-save.c
@@ -702,7 +702,7 @@ save_layer (TIFF        *tif,
 
   if (alpha)
     {
-      if (config_save_transp_pixels ||
+      if (config_save_transp_pixels &&
           /* Associated alpha, hence premultiplied components is
            * meaningless for palette images with transparency in TIFF
            * format, since alpha is set per pixel, not per color (so a


### PR DESCRIPTION
Reading the comment, this change seems the right logic.
Otherwise, *all* files are saved with EXTRASAMPLE_UNASSALPHA.