### PR TITLE
Finnish translation changes

### DIFF
--- a/po/fi.po
+++ b/po/fi.po
@@ -5266,7 +5266,7 @@ msgstr ""
 #: ../app/actions/filters-actions.c:59
 msgctxt "filters-action"
 msgid "Filte_rs"
-msgstr "_Suotimet"
+msgstr "_Suodattimet"
 
 #: ../app/actions/filters-actions.c:61
 msgctxt "filters-action"
@@ -8544,7 +8544,7 @@ msgstr "Muokkaa kuviota"
 #: ../app/actions/plug-in-actions.c:84
 msgctxt "plug-in-action"
 msgid "Reset all _Filters"
-msgstr "Nollaa kaikki _suotimet"
+msgstr "Nollaa kaikki _suodattimet"
 
 #: ../app/actions/plug-in-actions.c:85
 msgctxt "plug-in-action"
@@ -10465,7 +10465,7 @@ msgstr "Näytä yleisikkuna tälle kuvalle"
 #: ../app/actions/view-actions.c:143
 msgctxt "view-action"
 msgid "Display _Filters..."
-msgstr "Näytä _suotimet..."
+msgstr "Näytä _suodattimet..."
 
 #: ../app/actions/view-actions.c:144
 msgctxt "view-action"
@@ -19559,11 +19559,11 @@ msgstr "Pudotettu puskuri"
 
 #: ../app/display/gimpdisplayshell-filter-dialog.c:79
 msgid "Color Display Filters"
-msgstr "Värinäyttösuotimet"
+msgstr "Värinäyttösuodattimet"
 
 #: ../app/display/gimpdisplayshell-filter-dialog.c:82
 msgid "Configure Color Display Filters"
-msgstr "Määritä värinäyttösuotimet"
+msgstr "Määritä värinäyttösuodattimet"
 
 #: ../app/display/gimpdisplayshell-handlers.c:944
 #, c-format


### PR DESCRIPTION
Replaced translation word for filter. Word "suodin" is very uncommon word in Finnish language, and should be replaced with more mainstream, common term that is "suodatin".