### PR TITLE
Changed gendered terms to be gender-neutral

### DIFF
--- a/app/core/gimpitem.c
+++ b/app/core/gimpitem.c
@@ -2609,7 +2609,7 @@ gimp_item_mask_bounds (GimpItem *item,
  * @height: (out) (optional): return location for the height
  *
  * Intersect the area of the @item and its image's selection mask.
- * The computed area is the bounding box of he selection within the
+ * The computed area is the bounding box of the selection within the
  * item.
  */
 gboolean

--- a/libgimpbase/gimpenv.c
+++ b/libgimpbase/gimpenv.c
@@ -1160,7 +1160,7 @@ gimp_path_get_user_writable_dir (GList *path)
       /*  this is tricky:
        *  if a file is e.g. owned by the current user but not user-writable,
        *  the user has no permission to write to the file regardless
-       *  of his group's or other's write permissions
+       *  of their group's or other's write permissions
        */
       if (!err && S_ISDIR (filestat.st_mode) &&
 

--- a/libgimpwidgets/gimpnumberpairentry.c
+++ b/libgimpwidgets/gimpnumberpairentry.c
@@ -504,7 +504,7 @@ gimp_number_pair_entry_get_ratio (GimpNumberPairEntry *entry)
  * @right: Right number in the entry.
  *
  * Forces setting the numbers displayed by a #GimpNumberPairEntry,
- * ignoring if the user has set his/her own value. The state of
+ * ignoring if the user has set their own value. The state of
  * user-override will not be changed.
  *
  * Since: 2.4

--- a/plug-ins/common/animation-play.c
+++ b/plug-ins/common/animation-play.c
@@ -1567,7 +1567,7 @@ zoomcombo_changed (GtkWidget *combo,
 {
   gint index = gtk_combo_box_get_active (GTK_COMBO_BOX (combo));
 
-  /* If no index, user is probably editing by hand. We wait for him to click "Enter". */
+  /* If no index, user is probably editing by hand. We wait for them to click "Enter". */
   if (index != -1)
     update_scale (get_scale (index));
 }

--- a/plug-ins/common/file-compressor.c
+++ b/plug-ins/common/file-compressor.c
@@ -41,7 +41,7 @@
  *
  * I added the xcfgz bit because having a default extension of xcf.gz
  * can confuse the file selection dialog box somewhat, forcing the
- * user to type sometimes when he/she otherwise wouldn't need to.
+ * user to type sometimes when they otherwise wouldn't need to.
  *
  * I later decided I didn't like it because I don't like to bloat
  * the file-extension namespace.  But I left in the recognition

--- a/plug-ins/common/file-pnm.c
+++ b/plug-ins/common/file-pnm.c
@@ -1102,7 +1102,7 @@ pnm_load_rawpfm (PNMScanner *scan,
           data[x] *= fabsf (info->scale_factor);
           /* Keep values smaller than zero. That is in line with what
            * the TIFF loader does. If the user doesn't want the
-           * negative numbers he has to get rid of them afterwards
+           * negative numbers they have to get rid of them afterwards
            */
           /* data[x] = fmaxf (0.0f, fminf (FLT_MAX, data[x])); */
         }

--- a/plug-ins/gradient-flare/gradient-flare.c
+++ b/plug-ins/gradient-flare/gradient-flare.c
@@ -824,7 +824,7 @@ gflare_create_procedure (GimpPlugIn  *plug_in,
                                         "This plug-in produces a lense flare "
                                         "effect using custom gradients. In "
                                         "interactive call, the user can edit "
-                                        "his/her own favorite lense flare "
+                                        "their own favorite lense flare "
                                         "(GFlare) and render it. Edited "
                                         "gflare is saved automatically to "
                                         "the folder in gflare-path, if it is "

--- a/plug-ins/script-fu/tinyscheme/Manual.txt
+++ b/plug-ins/script-fu/tinyscheme/Manual.txt
@@ -355,7 +355,7 @@ Please read accompanying file COPYING.
      Error Handling
      --------------
 
-     Errors are recovered from without damage. The user can install his
+     Errors are recovered from without damage. The user can install their
      own handler for system errors, by defining *error-hook*. Defining
      to '() gives the default behavior, which is equivalent to "error".
      USE_ERROR_HOOK must be defined.
@@ -390,7 +390,7 @@ Please read accompanying file COPYING.
 
      which makes use of the error hook described above.
 
-     If necessary, the user can devise his own exception mechanism with
+     If necessary, the user can devise their own exception mechanism with
      tagged exceptions etc.
 
 
@@ -416,7 +416,7 @@ Please read accompanying file COPYING.
      where <qualifier> is a symbol not containing any double-colons.
 
      As the definition is recursive, qualifiers can be nested.
-     The user can define his own *colon-hook*, to handle qualified names.
+     The user can define their own *colon-hook*, to handle qualified names.
      By default, "init.scm" defines *colon-hook* as EVAL. Consequently,
      the qualifier must denote a Scheme environment, such as one returned
      by (interaction-environment). "Init.scm" defines a new syntantic form,


### PR DESCRIPTION
Changed a handful of gendered terms to be gender-neutral, and one typo of 'he' to 'the' where appropriate. 